### PR TITLE
Converting an exponential number into its decimal form

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -376,6 +376,9 @@ class Utils
                 $negative1 = new BigInteger(-1);
             }
             if (strpos($number, '.') > 0) {
+                if (stripos($number, 'e')) {
+                    $number = rtrim(rtrim(sprintf("%.18f", $number), '0'), '.');
+                }
                 $comps = explode('.', $number);
 
                 if (count($comps) > 2) {


### PR DESCRIPTION
Hello Fenguoz,
I hope you are doing well. First of all, I would like to thank you for this library - I really appreciate your time and effort.

While using your library I encountered situation that might be a potential issue. 
In the Bnb.php file, the transfer function has the following signature: 
`public function transfer(string $privateKey, string $to, float $value, string $gasPrice = 'standard')`
Here the $value parameter is type of float. When I pass a small amount like '0.00001' it gets converted to '1.0E-5'. Then, inside the `Utils::toBn()` function in block from line 370 this number will be converted to '1'. 

As a result, attempting to send 0.00001 BNB results in sending 1 BNB, which can be critical.

Let me know what you think. Thanks again for your great work!

